### PR TITLE
Fix the issue that prompt texts can't be displayed on console when using maven 3.5.0.

### DIFF
--- a/common/src/main/java/org/unidal/maven/plugin/common/PropertyProviders.java
+++ b/common/src/main/java/org/unidal/maven/plugin/common/PropertyProviders.java
@@ -81,6 +81,7 @@ public class PropertyProviders {
             } else {
                System.out.print(sb.toString());
             }
+            System.out.flush();
 
             try {
                int size = System.in.read(buffer);


### PR DESCRIPTION
When using codegen:code goal with maven 3.5.0, the "Please enter text:" prompt string is unable to be displayed immediately on the console due to output stream buffering. This change is made to fix it.